### PR TITLE
Domänen 3 und 4 auskommentiert um Verwirrungen zu vermeiden.

### DIFF
--- a/config.js
+++ b/config.js
@@ -10,8 +10,8 @@ modes: {
 sites:{
   "domaene01" : {id: "domaene01",short:"d01",name:"Münster Stadt", version:"1.0.4", version_base:"2016.1.2", on_map: true },
   "domaene02" : {id: "domaene02",short:"d02",name:"Kreis Coesfeld", version:"1.0.4", version_base:"2016.1.2", on_map: true },
-  "domaene03" : {id: "domaene03",short:"d03",name:"Kreis Steinfurt West", version:"1.0.4", version_base:"2016.1.2", on_map: false },
-  "domaene04" : {id: "domaene04",short:"d04",name:"Kreis Steinfurt Ost", version:"1.0.4", version_base:"2016.1.2", on_map: false },
+  //"domaene03" : {id: "domaene03",short:"d03",name:"Kreis Steinfurt West", version:"1.0.4", version_base:"2016.1.2", on_map: false },
+  //"domaene04" : {id: "domaene04",short:"d04",name:"Kreis Steinfurt Ost", version:"1.0.4", version_base:"2016.1.2", on_map: false },
   "domaene05" : {id: "domaene05",short:"d05",name:"Münster Süd", version:"1.0.4", version_base:"2016.1.2", on_map: true },
   "domaene06" : {id: "domaene06",short:"d06",name:"Westmünsterland", version:"1.0.4", version_base:"2016.1.2", on_map: true },
   "domaene07" : {id: "domaene07",short:"d07",name:"Telgte", version:"1.1.3", version_base:"2016.1.x", on_map: true },


### PR DESCRIPTION
Die Links verliefen ins leere da die Firmware entfernt wurde.
